### PR TITLE
fix: key formatting sometimes swallows characters

### DIFF
--- a/src/impl/format.ts
+++ b/src/impl/format.ts
@@ -206,7 +206,11 @@ export function format(documentText: string, range: Range | undefined, options: 
 					if (!hasError) {
 						if (secondToken === SyntaxKind.ColonToken) {
 							if (options.keyQuotes) {
-								addEdit(formalizeString(firstTokenValue, documentText.substring(firstTokenStart, actualFirstTokenEnd).slice(1, -1), options.keyQuotes), firstTokenStart, actualFirstTokenEnd);
+								let keyName = documentText.substring(firstTokenStart, actualFirstTokenEnd);
+								if (keyName.startsWith('"')) {
+									keyName = keyName.slice(1, -1)
+								}
+								addEdit(formalizeString(firstTokenValue, keyName, options.keyQuotes), firstTokenStart, actualFirstTokenEnd);
 							}
 						}
 						else if (options.stringQuotes) {


### PR DESCRIPTION
Fixed an issue where formatting a key without quotes with the intention to add quotes swallows the first and last letter of the key.