### PR TITLE
Fix bug when parsing Hex values

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blueglassblock/json5-kit",
-  "version": "0.2.4",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@blueglassblock/json5-kit",
-      "version": "0.2.4",
+      "version": "0.3.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^10.0.7",

--- a/src/impl/scanner.ts
+++ b/src/impl/scanner.ts
@@ -346,10 +346,11 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 
 			case CharacterCodes._0:
 				// 0 may lead to a hexadecimal number
+				let startPosHex = pos;
 				pos++;
 				if (text.charCodeAt(pos) === CharacterCodes.x || text.charCodeAt(pos) === CharacterCodes.X) {
 					value += '0';
-					value += String.fromCharCode(code);
+					value += String.fromCharCode(text.charCodeAt(pos));
 					pos++;
 					if (pos === len ||
 						!(isDigit(text.charCodeAt(pos)) ||
@@ -361,11 +362,12 @@ export function createScanner(text: string, ignoreTrivia: boolean = false): JSON
 						(isDigit(text.charCodeAt(pos))
 							|| (text.charCodeAt(pos) >= CharacterCodes.A && text.charCodeAt(pos) <= CharacterCodes.F)
 							|| (text.charCodeAt(pos) >= CharacterCodes.a && text.charCodeAt(pos) <= CharacterCodes.f))) {
+						value += String.fromCharCode(text.charCodeAt(pos));
 						pos++;
 					}
 					return token = SyntaxKind.NumericLiteral;
 				}
-				pos--; // Backtrace
+				pos = startPosHex; // Backtrace
 			case CharacterCodes._1:
 			case CharacterCodes._2:
 			case CharacterCodes._3:

--- a/src/test/json.test.ts
+++ b/src/test/json.test.ts
@@ -218,7 +218,7 @@ suite('JSON', () => {
 		assertKinds('NaN', SyntaxKind.NumericLiteral);
 		assertKinds('+NaN', SyntaxKind.NumericLiteral);
 		assertKinds('-NaN', SyntaxKind.NumericLiteral);
-		
+
 
 		// unexpected end
 		assertKinds('-', SyntaxKind.Unknown);
@@ -303,7 +303,7 @@ suite('JSON', () => {
 	});
 
 	test('parse: objects with errors', () => {
-		assertInvalidParse('{,}', {});	
+		assertInvalidParse('{,}', {});
 		assertInvalidParse('{ "bar": 8 "xoo": "foo" }', { bar: 8, xoo: 'foo' });
 		assertInvalidParse('{ ,"bar": 8 }', { bar: 8 });
 		assertInvalidParse('{ ,"bar": 8, "foo" }', { bar: 8 });
@@ -371,6 +371,7 @@ suite('JSON', () => {
 		assertTree('23', { type: 'number', offset: 0, length: 2, value: 23 });
 		assertTree('-1.93e-19', { type: 'number', offset: 0, length: 9, value: -1.93e-19 });
 		assertTree('"hello"', { type: 'string', offset: 0, length: 7, value: 'hello' });
+		assertTree('0x50', { type: 'number', offset: 0, length: 4, value: 0x50 });
 	});
 
 	test('tree: arrays', () => {


### PR DESCRIPTION
Previously hex values where always parsed as 00, instead of the real value. 
The change parsed hex values as their real values.

When validating a `json5` file, like:


```json5
{
    "$schema": "./schema.json",
    a: 0x50
}
```

With the `schema.json`:
```json
{
    "$schema": "https://json-schema.org/draft/2020-12/schema",
    "type":"object",
    "properties": {
        "a":{
            "type":"number",
            "minimum": 5
        }
    }
}
```

The better json5 VSCode extension reported `"Value is below the minimum of 5."`, which is incorrect.
The json5-kit parser ignored the hex-value and pared it as `00`.
